### PR TITLE
#24 - Adding all packages storage to repository

### DIFF
--- a/src/main/java/com/artipie/composer/AllPackages.java
+++ b/src/main/java/com/artipie/composer/AllPackages.java
@@ -1,0 +1,38 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.composer;
+
+import com.artipie.asto.Key;
+
+/**
+ * Key for all packages value.
+ *
+ * @since 0.1
+ */
+public final class AllPackages implements Key {
+    @Override
+    public String string() {
+        return "packages.json";
+    }
+}

--- a/src/main/java/com/artipie/composer/Repository.java
+++ b/src/main/java/com/artipie/composer/Repository.java
@@ -55,20 +55,20 @@ public class Repository {
     /**
      * Reads packages description from storage.
      *
+     * @return Packages found by name, might be empty.
+     */
+    public Packages packages() {
+        return this.packages(new AllPackages());
+    }
+
+    /**
+     * Reads packages description from storage.
+     *
      * @param name Package name.
      * @return Packages found by name, might be empty.
      */
     public Packages packages(final Name name) {
-        final Key key = name.key();
-        final BlockingStorage blocking = new BlockingStorage(this.storage);
-        final JsonPackages packages;
-        if (blocking.exists(key)) {
-            final ByteSource content = ByteSource.wrap(blocking.value(key));
-            packages = new JsonPackages(content);
-        } else {
-            packages = new JsonPackages();
-        }
-        return packages;
+        return this.packages(name.key());
     }
 
     /**
@@ -85,5 +85,23 @@ public class Repository {
         return this.packages(name)
             .add(pack)
             .save(this.storage, name.key());
+    }
+
+    /**
+     * Reads packages description from storage.
+     *
+     * @param key Content location in storage.
+     * @return Packages found by name, might be empty.
+     */
+    private Packages packages(final Key key) {
+        final BlockingStorage blocking = new BlockingStorage(this.storage);
+        final JsonPackages packages;
+        if (blocking.exists(key)) {
+            final ByteSource content = ByteSource.wrap(blocking.value(key));
+            packages = new JsonPackages(content);
+        } else {
+            packages = new JsonPackages();
+        }
+        return packages;
     }
 }

--- a/src/test/java/com/artipie/composer/RepositoryAddTest.java
+++ b/src/test/java/com/artipie/composer/RepositoryAddTest.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package com.artipie.composer;
 
 import com.artipie.asto.Key;
@@ -40,18 +39,17 @@ import javax.json.JsonWriter;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.collection.IsEmptyCollection;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-// @checkstyle ClassDataAbstractionCouplingCheck (6 lines)
 /**
- * Tests for {@link Repository}.
+ * Tests for {@link Repository#add(Key)}.
  *
  * @since 0.1
+ * @checkstyle ClassDataAbstractionCouplingCheck (2 lines)
  */
-class RepositoryTest {
+class RepositoryAddTest {
 
     /**
      * Storage used in tests.
@@ -70,32 +68,6 @@ class RepositoryTest {
             ByteSource.wrap(
                 ByteStreams.toByteArray(new ResourceOf("minimal-package.json").stream())
             )
-        );
-    }
-
-    @Test
-    void shouldLoadEmptyPackages() throws Exception {
-        final Name name = new Name("foo/bar");
-        final Packages packages = new Repository(this.storage).packages(name);
-        packages.save(this.storage, name.key()).get();
-        MatcherAssert.assertThat(
-            "Packages loaded when no content is in storage should be empty",
-            this.packages(name).keySet(),
-            new IsEmptyCollection<>()
-        );
-    }
-
-    @Test
-    void shouldLoadNonEmptyPackages() throws Exception {
-        final Name name = new Name("foo/bar2");
-        final byte[] bytes = "some data".getBytes();
-        new BlockingStorage(this.storage).save(name.key(), bytes);
-        final Packages packages = new Repository(this.storage).packages(name);
-        packages.save(this.storage, name.key()).get();
-        MatcherAssert.assertThat(
-            "Packages loaded and saved should preserve content without modification",
-            new BlockingStorage(this.storage).value(name.key()),
-            new IsEqual<>(bytes)
         );
     }
 

--- a/src/test/java/com/artipie/composer/RepositoryPackagesTest.java
+++ b/src/test/java/com/artipie/composer/RepositoryPackagesTest.java
@@ -1,0 +1,117 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.composer;
+
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.asto.memory.InMemoryStorage;
+import java.io.ByteArrayInputStream;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.collection.IsEmptyCollection;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Repository#packages()} and {@link Repository#packages(Name)}.
+ *
+ * @since 0.1
+ * @checkstyle ClassDataAbstractionCouplingCheck (2 lines)
+ */
+class RepositoryPackagesTest {
+
+    /**
+     * Storage used in tests.
+     */
+    private Storage storage;
+
+    @BeforeEach
+    void init() {
+        this.storage = new InMemoryStorage();
+    }
+
+    @Test
+    void shouldLoadEmptyPackages() throws Exception {
+        final Name name = new Name("foo/bar");
+        final Packages packages = new Repository(this.storage).packages(name);
+        packages.save(this.storage, name.key()).get();
+        MatcherAssert.assertThat(
+            this.packages(name).keySet(),
+            new IsEmptyCollection<>()
+        );
+    }
+
+    @Test
+    void shouldLoadNonEmptyPackages() throws Exception {
+        final Name name = new Name("foo/bar2");
+        final byte[] bytes = "some data".getBytes();
+        new BlockingStorage(this.storage).save(name.key(), bytes);
+        final Packages packages = new Repository(this.storage).packages(name);
+        packages.save(this.storage, name.key()).get();
+        MatcherAssert.assertThat(
+            new BlockingStorage(this.storage).value(name.key()),
+            new IsEqual<>(bytes)
+        );
+    }
+
+    @Test
+    void shouldLoadEmptyAllPackages() throws Exception {
+        final Packages packages = new Repository(this.storage).packages();
+        packages.save(this.storage, new AllPackages()).get();
+        MatcherAssert.assertThat(this.packages().keySet(), new IsEmptyCollection<>());
+    }
+
+    @Test
+    void shouldLoadNonEmptyAllPackages() throws Exception {
+        final byte[] bytes = "all packages".getBytes();
+        new BlockingStorage(this.storage).save(new AllPackages(), bytes);
+        final Packages packages = new Repository(this.storage).packages();
+        packages.save(this.storage, new AllPackages()).get();
+        MatcherAssert.assertThat(
+            new BlockingStorage(this.storage).value(new AllPackages()),
+            new IsEqual<>(bytes)
+        );
+    }
+
+    private JsonObject packages() {
+        return this.packages(new AllPackages());
+    }
+
+    private JsonObject packages(final Name name) {
+        return this.packages(name.key());
+    }
+
+    private JsonObject packages(final Key key) {
+        final JsonObject saved;
+        final byte[] bytes = new BlockingStorage(this.storage).value(key);
+        try (JsonReader reader = Json.createReader(new ByteArrayInputStream(bytes))) {
+            saved = reader.readObject();
+        }
+        return saved.getJsonObject("packages");
+    }
+}


### PR DESCRIPTION
Part of #24 
Added all packages storage to repository, required for simple repository implementation.
Split RepositoryTest into parts by method tested.