### PR TITLE
#23 - Obtain composer json file from archive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,12 @@ SOFTWARE.
       <version>0.17.7</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.20</version>
+    </dependency>
+    <!-- Test scope -->
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/src/main/java/com/artipie/composer/AstoRepository.java
+++ b/src/main/java/com/artipie/composer/AstoRepository.java
@@ -28,6 +28,7 @@ import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.ext.PublisherAs;
+import com.artipie.composer.http.Archive;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -74,7 +75,7 @@ public final class AstoRepository implements Repository {
     public CompletableFuture<Void> addJson(final Content content) {
         final Key key = new Key.From(UUID.randomUUID().toString());
         return this.storage.save(key, content).thenCompose(
-            saved -> this.storage.value(key)
+            nothing -> this.storage.value(key)
                 .thenApply(PublisherAs::new)
                 .thenCompose(PublisherAs::bytes)
                 .thenCompose(
@@ -108,7 +109,7 @@ public final class AstoRepository implements Repository {
     }
 
     @Override
-    public CompletableFuture<Void> addZip(final Content content) {
+    public CompletableFuture<Void> addArchive(final Archive archive, final Content content) {
         throw new NotImplementedException("not implemented yet");
     }
 

--- a/src/main/java/com/artipie/composer/Repository.java
+++ b/src/main/java/com/artipie/composer/Repository.java
@@ -25,6 +25,7 @@
 package com.artipie.composer;
 
 import com.artipie.asto.Content;
+import com.artipie.composer.http.Archive;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -60,10 +61,12 @@ public interface Repository {
     CompletableFuture<Void> addJson(Content content);
 
     /**
-     * Adds package described in ZIP format from storage.
+     * Adds package described in archive with ZIP or TAR.GZ
+     * format from storage.
      *
+     * @param archive Archive with package content.
      * @param content Package content.
      * @return Completion of adding package to repository.
      */
-    CompletableFuture<Void> addZip(Content content);
+    CompletableFuture<Void> addArchive(Archive archive, Content content);
 }

--- a/src/main/java/com/artipie/composer/http/AddArchiveSlice.java
+++ b/src/main/java/com/artipie/composer/http/AddArchiveSlice.java
@@ -38,10 +38,11 @@ import org.reactivestreams.Publisher;
 
 /**
  * Slice for adding a package to the repository in ZIP format.
+ * See <a href="https://getcomposer.org/doc/05-repositories.md#artifact">Artifact repository</a>.
  * @since 0.4
  */
 @SuppressWarnings({"PMD.SingularField", "PMD.UnusedPrivateField"})
-final class AddZipSlice implements Slice {
+final class AddArchiveSlice implements Slice {
     /**
      * Composer HTTP for entry point.
      * See <a href="https://getcomposer.org/doc/04-schema.md#version">docs</a>.
@@ -59,7 +60,7 @@ final class AddZipSlice implements Slice {
      * Ctor.
      * @param repository Repository.
      */
-    AddZipSlice(final Repository repository) {
+    AddArchiveSlice(final Repository repository) {
         this.repository = repository;
     }
 
@@ -71,7 +72,7 @@ final class AddZipSlice implements Slice {
     ) {
         final RequestLineFrom rqline = new RequestLineFrom(line);
         final String uri = rqline.uri().getPath();
-        final Matcher matcher = AddZipSlice.PATH.matcher(uri);
+        final Matcher matcher = AddArchiveSlice.PATH.matcher(uri);
         final Response resp;
         if (matcher.matches()) {
             throw new NotImplementedException("not implemented yet");

--- a/src/main/java/com/artipie/composer/http/Archive.java
+++ b/src/main/java/com/artipie/composer/http/Archive.java
@@ -1,0 +1,106 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.composer.http;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.ext.PublisherAs;
+import com.artipie.composer.misc.ContentAsJson;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.CompletionStage;
+import javax.json.JsonObject;
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+import org.apache.commons.compress.utils.IOUtils;
+
+/**
+ * Interface for working with archive file. For example, obtaining
+ * composer json file from archive.
+ * @since 0.4
+ */
+public interface Archive {
+    /**
+     * Obtains composer json file from archive.
+     * @return Composer json file from archive.
+     */
+    CompletionStage<JsonObject> composer();
+
+    /**
+     * Archive in ZIP format.
+     * @since 0.4
+     */
+    class Zip implements Archive {
+        /**
+         * Content of ZIP archive.
+         */
+        private final Content content;
+
+        /**
+         * Ctor.
+         * @param content Content of ZIP archive
+         */
+        public Zip(final Content content) {
+            this.content = content;
+        }
+
+        @Override
+        public CompletionStage<JsonObject> composer() {
+            return this.file("composer.json")
+                .thenApply(ContentAsJson::new)
+                .thenCompose(ContentAsJson::value);
+        }
+
+        /**
+         * Obtain file by name.
+         * @param name The name of a file
+         * @return The file content.
+         */
+        @SuppressWarnings("PMD.AssignmentInOperand")
+        private CompletionStage<Content> file(final String name) {
+            return new PublisherAs(this.content).bytes()
+                .thenApply(
+                    bytes -> {
+                        try (
+                            ByteArrayInputStream bytearr = new ByteArrayInputStream(bytes);
+                            ZipArchiveInputStream zip = new ZipArchiveInputStream(bytearr)
+                        ) {
+                            ArchiveEntry entry;
+                            while ((entry = zip.getNextZipEntry()) != null) {
+                                final String[] parts = entry.getName().split("/");
+                                if (parts[parts.length - 1].equals(name)) {
+                                    return new Content.From(IOUtils.toByteArray(zip));
+                                }
+                            }
+                            throw new IllegalStateException(
+                                String.format("'%s' file was not found", name)
+                            );
+                        } catch (final IOException exc) {
+                            throw new UncheckedIOException(exc);
+                        }
+                    }
+            );
+        }
+    }
+}

--- a/src/test/java/com/artipie/composer/http/AddArchiveSliceTest.java
+++ b/src/test/java/com/artipie/composer/http/AddArchiveSliceTest.java
@@ -40,11 +40,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 /**
- * Tests for {@link AddZipSlice}.
+ * Tests for {@link AddArchiveSlice}.
  *
  * @since 0.4
  */
-final class AddZipSliceTest {
+final class AddArchiveSliceTest {
     /**
      * Test storage.
      */
@@ -67,7 +67,7 @@ final class AddZipSliceTest {
     void patternExtractsNameAndVersionCorrectly(
         final String url, final String name, final String vers
     ) {
-        final Matcher matcher = AddZipSlice.PATH.matcher(url);
+        final Matcher matcher = AddArchiveSlice.PATH.matcher(url);
         final String cname;
         final String cvers;
         if (matcher.matches()) {
@@ -92,7 +92,7 @@ final class AddZipSliceTest {
     @Test
     void returnsBadRequest() {
         MatcherAssert.assertThat(
-            new AddZipSlice(new AstoRepository(this.storage)),
+            new AddArchiveSlice(new AstoRepository(this.storage)),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.BAD_REQUEST),
                 new RequestLine(RqMethod.GET, "/bad/request")

--- a/src/test/java/com/artipie/composer/http/ArchiveZipTest.java
+++ b/src/test/java/com/artipie/composer/http/ArchiveZipTest.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.composer.http;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.test.TestResource;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Archive.Zip}.
+ * @since 0.4
+ */
+public class ArchiveZipTest {
+    @Test
+    void obtainingComposerJsonWorks() {
+        MatcherAssert.assertThat(
+            new Archive.Zip(
+                new Content.From(new TestResource("log-1.1.3.zip").asBytes())
+            ).composer()
+            .toCompletableFuture().join()
+            .getString("name"),
+            new IsEqual<>("psr/log")
+        );
+    }
+}


### PR DESCRIPTION
Part of #23 
Implemented obtaining composer json file from archive. Added `Archive` interface because potentially `.zip` and `.tar.gz` are possible