### PR TITLE
#23 - Add IT for uploading and install of ZIP archive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.33.6</version>
+      <version>0.34</version>
     </dependency>
     <dependency>
       <groupId>javax.json</groupId>

--- a/src/main/java/com/artipie/composer/http/AddArchiveSlice.java
+++ b/src/main/java/com/artipie/composer/http/AddArchiveSlice.java
@@ -76,15 +76,13 @@ final class AddArchiveSlice implements Slice {
         final Matcher matcher = AddArchiveSlice.PATH.matcher(uri);
         final Response resp;
         if (matcher.matches()) {
-            final Content content = new Content.From(body);
             resp = new AsyncResponse(
                 this.repository
                     .addArchive(
                         new Archive.Zip(
-                            new Archive.Name(matcher.group("full"), matcher.group("version")),
-                            content
+                            new Archive.Name(matcher.group("full"), matcher.group("version"))
                         ),
-                        content
+                        new Content.From(body)
                     )
                     .thenApply(nothing -> new RsWithStatus(RsStatus.CREATED))
             );

--- a/src/main/java/com/artipie/composer/http/PhpComposer.java
+++ b/src/main/java/com/artipie/composer/http/PhpComposer.java
@@ -78,6 +78,17 @@ public final class PhpComposer extends Slice.Wrap {
                         auth,
                         new Permission.ByName(perms, Action.Standard.WRITE)
                     )
+                ),
+                new RtRulePath(
+                    new RtRule.All(
+                        new RtRule.ByPath(AddArchiveSlice.PATH),
+                        ByMethodsRule.Standard.PUT
+                    ),
+                    new BasicAuthSlice(
+                        new AddArchiveSlice(repository),
+                        auth,
+                        new Permission.ByName(perms, Action.Standard.WRITE)
+                    )
                 )
             )
         );

--- a/src/test/java/com/artipie/composer/AstoRepositoryAddArchiveTest.java
+++ b/src/test/java/com/artipie/composer/AstoRepositoryAddArchiveTest.java
@@ -111,7 +111,7 @@ final class AstoRepositoryAddArchiveTest {
     private void saveZipArchive() {
         new AstoRepository(this.storage)
             .addArchive(
-                new Archive.Zip(this.name, this.archive),
+                new Archive.Zip(this.name),
                 this.archive
             ).join();
     }

--- a/src/test/java/com/artipie/composer/http/RepositoryHttpIT.java
+++ b/src/test/java/com/artipie/composer/http/RepositoryHttpIT.java
@@ -210,9 +210,9 @@ class RepositoryHttpIT {
 
     private static byte[] emptyZip() throws Exception {
         final ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        try (ZipOutputStream zip = new ZipOutputStream(bos)) {
-            zip.putNextEntry(new ZipEntry("whatever"));
-        }
+        final ZipOutputStream zos = new ZipOutputStream(bos);
+        zos.putNextEntry(new ZipEntry("whatever"));
+        zos.close();
         return bos.toByteArray();
     }
 }

--- a/src/test/resources-binary/log-composer-with-version.json
+++ b/src/test/resources-binary/log-composer-with-version.json
@@ -1,0 +1,1 @@
+{"name":"psr/log","version":"1.1.3","description":"Common interface for logging libraries","keywords":["psr","psr-3","log"],"homepage":"https://github.com/php-fig/log","license":"MIT","authors":[{"name":"PHP-FIG","homepage":"http://www.php-fig.org/"}],"require":{"php":">=5.3.0"},"autoload":{"psr-4":{"Psr\\Log\\":"Psr/Log/"}},"extra":{"branch-alias":{"dev-master":"1.1.x-dev"}}}


### PR DESCRIPTION
Closes #23
Added IT for uploading and install of archive in `ZIP` format. As `composer.json` does not contain information about version this file is changed a bit during adding archive to our storage.