### PR TITLE
#92 - Add IT for install archive with composer, add slice for download archive

### DIFF
--- a/src/main/java/com/artipie/composer/Repository.java
+++ b/src/main/java/com/artipie/composer/Repository.java
@@ -25,6 +25,7 @@
 package com.artipie.composer;
 
 import com.artipie.asto.Content;
+import com.artipie.asto.Key;
 import com.artipie.composer.http.Archive;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -69,4 +70,11 @@ public interface Repository {
      * @return Completion of adding package to repository.
      */
     CompletableFuture<Void> addArchive(Archive archive, Content content);
+
+    /**
+     * Obtain bytes by key.
+     * @param key The key
+     * @return Bytes.
+     */
+    CompletableFuture<Content> value(Key key);
 }

--- a/src/main/java/com/artipie/composer/http/DownloadArchiveSlice.java
+++ b/src/main/java/com/artipie/composer/http/DownloadArchiveSlice.java
@@ -34,8 +34,6 @@ import com.artipie.http.rs.RsWithStatus;
 import com.artipie.http.slice.KeyFromPath;
 import java.nio.ByteBuffer;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.reactivestreams.Publisher;
 
 /**
@@ -43,11 +41,6 @@ import org.reactivestreams.Publisher;
  * @since 0.4
  */
 final class DownloadArchiveSlice implements Slice {
-    /**
-     * Pattern for uploading archives endpoint.
-     */
-    static final Pattern PATH = Pattern.compile("^/?artifacts/.*\\.zip$");
-
     /**
      * Repository.
      */
@@ -67,19 +60,11 @@ final class DownloadArchiveSlice implements Slice {
         final Iterable<Map.Entry<String, String>> headers,
         final Publisher<ByteBuffer> body
     ) {
-        final RequestLineFrom rqline = new RequestLineFrom(line);
-        final String uri = rqline.uri().getPath();
-        final Matcher matcher = DownloadArchiveSlice.PATH.matcher(uri);
-        final Response resp;
-        if (matcher.matches()) {
-            resp = new AsyncResponse(
-                this.repos.value(new KeyFromPath(uri))
-                    .thenApply(RsWithBody::new)
-                    .thenApply(rsp -> new RsWithStatus(rsp, RsStatus.OK))
-            );
-        }  else {
-            resp = new RsWithStatus(RsStatus.BAD_REQUEST);
-        }
-        return resp;
+        final String path = new RequestLineFrom(line).uri().getPath();
+        return new AsyncResponse(
+            this.repos.value(new KeyFromPath(path))
+                .thenApply(RsWithBody::new)
+                .thenApply(rsp -> new RsWithStatus(rsp, RsStatus.OK))
+        );
     }
 }

--- a/src/main/java/com/artipie/composer/http/DownloadArchiveSlice.java
+++ b/src/main/java/com/artipie/composer/http/DownloadArchiveSlice.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.composer.http;
+
+import com.artipie.composer.Repository;
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncResponse;
+import com.artipie.http.rq.RequestLineFrom;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithBody;
+import com.artipie.http.rs.RsWithStatus;
+import com.artipie.http.slice.KeyFromPath;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.reactivestreams.Publisher;
+
+/**
+ * Slice for uploading archive by key from storage.
+ * @since 0.4
+ */
+final class DownloadArchiveSlice implements Slice {
+    /**
+     * Pattern for uploading archives endpoint.
+     */
+    static final Pattern PATH = Pattern.compile("^/?artifacts/.*\\.zip$");
+
+    /**
+     * Repository.
+     */
+    private final Repository repos;
+
+    /**
+     * Slice by key from storage.
+     * @param repository Repository
+     */
+    DownloadArchiveSlice(final Repository repository) {
+        this.repos = repository;
+    }
+
+    @Override
+    public Response response(
+        final String line,
+        final Iterable<Map.Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body
+    ) {
+        final RequestLineFrom rqline = new RequestLineFrom(line);
+        final String uri = rqline.uri().getPath();
+        final Matcher matcher = DownloadArchiveSlice.PATH.matcher(uri);
+        final Response resp;
+        if (matcher.matches()) {
+            resp = new AsyncResponse(
+                this.repos.value(new KeyFromPath(uri))
+                    .thenApply(RsWithBody::new)
+                    .thenApply(rsp -> new RsWithStatus(rsp, RsStatus.OK))
+            );
+        }  else {
+            resp = new RsWithStatus(RsStatus.BAD_REQUEST);
+        }
+        return resp;
+    }
+}

--- a/src/main/java/com/artipie/composer/http/PhpComposer.java
+++ b/src/main/java/com/artipie/composer/http/PhpComposer.java
@@ -34,6 +34,7 @@ import com.artipie.http.rt.ByMethodsRule;
 import com.artipie.http.rt.RtRule;
 import com.artipie.http.rt.RtRulePath;
 import com.artipie.http.rt.SliceRoute;
+import java.util.regex.Pattern;
 
 /**
  * PHP Composer repository HTTP front end.
@@ -70,7 +71,7 @@ public final class PhpComposer extends Slice.Wrap {
                 ),
                 new RtRulePath(
                     new RtRule.All(
-                        new RtRule.ByPath(DownloadArchiveSlice.PATH),
+                        new RtRule.ByPath(Pattern.compile("^/?artifacts/.*\\.zip$")),
                         ByMethodsRule.Standard.GET
                     ),
                     new BasicAuthSlice(

--- a/src/main/java/com/artipie/composer/http/PhpComposer.java
+++ b/src/main/java/com/artipie/composer/http/PhpComposer.java
@@ -70,6 +70,17 @@ public final class PhpComposer extends Slice.Wrap {
                 ),
                 new RtRulePath(
                     new RtRule.All(
+                        new RtRule.ByPath(DownloadArchiveSlice.PATH),
+                        ByMethodsRule.Standard.GET
+                    ),
+                    new BasicAuthSlice(
+                        new DownloadArchiveSlice(repository),
+                        auth,
+                        new Permission.ByName(perms, Action.Standard.READ)
+                    )
+                ),
+                new RtRulePath(
+                    new RtRule.All(
                         new RtRule.ByPath(AddSlice.PATH_PATTERN),
                         ByMethodsRule.Standard.PUT
                     ),

--- a/src/test/java/com/artipie/composer/AstoRepositoryAddArchiveTest.java
+++ b/src/test/java/com/artipie/composer/AstoRepositoryAddArchiveTest.java
@@ -31,6 +31,7 @@ import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
 import com.artipie.composer.http.Archive;
 import com.artipie.composer.misc.ContentAsJson;
+import java.util.Optional;
 import javax.json.JsonObject;
 import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
@@ -109,7 +110,7 @@ final class AstoRepositoryAddArchiveTest {
     }
 
     private void saveZipArchive() {
-        new AstoRepository(this.storage)
+        new AstoRepository(this.storage, Optional.of("http://artipie:8080/"))
             .addArchive(
                 new Archive.Zip(this.name),
                 this.archive

--- a/src/test/java/com/artipie/composer/http/AddArchiveSliceTest.java
+++ b/src/test/java/com/artipie/composer/http/AddArchiveSliceTest.java
@@ -34,6 +34,7 @@ import com.artipie.http.hm.SliceHasResponse;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.RsStatus;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -107,8 +108,11 @@ final class AddArchiveSliceTest {
     @Test
     void returnsCreateStatus() {
         final String archive = "log-1.1.3.zip";
+        final AstoRepository asto = new AstoRepository(
+            this.storage, Optional.of("http://artipie:8080/")
+        );
         MatcherAssert.assertThat(
-            new AddArchiveSlice(new AstoRepository(this.storage)),
+            new AddArchiveSlice(asto),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.CREATED),
                 new RequestLine(RqMethod.PUT, String.format("/%s", archive)),

--- a/src/test/java/com/artipie/composer/http/DownloadArchiveSliceTest.java
+++ b/src/test/java/com/artipie/composer/http/DownloadArchiveSliceTest.java
@@ -36,7 +36,6 @@ import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.RsStatus;
 import org.hamcrest.MatcherAssert;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -45,35 +44,15 @@ import org.junit.jupiter.api.Test;
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 final class DownloadArchiveSliceTest {
-    /**
-     * Test storage.
-     */
-    private Storage storage;
-
-    @BeforeEach
-    void setUp() {
-        this.storage = new InMemoryStorage();
-    }
-
-    @Test
-    void returnsBadRequest() {
-        MatcherAssert.assertThat(
-            new DownloadArchiveSlice(new AstoRepository(this.storage)),
-            new SliceHasResponse(
-                new RsHasStatus(RsStatus.BAD_REQUEST),
-                new RequestLine(RqMethod.GET, "/bad/request")
-            )
-        );
-    }
-
     @Test
     void returnsOkStatus() {
+        final Storage storage = new InMemoryStorage();
         final String archive = "log-1.1.3.zip";
         final Key key = new Key.From("artifacts", archive);
         new TestResource(archive)
-            .saveTo(this.storage, key);
+            .saveTo(storage, key);
         MatcherAssert.assertThat(
-            new DownloadArchiveSlice(new AstoRepository(this.storage)),
+            new DownloadArchiveSlice(new AstoRepository(storage)),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.OK),
                 new RequestLine(RqMethod.GET, key.string()),

--- a/src/test/java/com/artipie/composer/http/DownloadArchiveSliceTest.java
+++ b/src/test/java/com/artipie/composer/http/DownloadArchiveSliceTest.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.composer.http;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.asto.test.TestResource;
+import com.artipie.composer.AstoRepository;
+import com.artipie.http.Headers;
+import com.artipie.http.hm.RsHasStatus;
+import com.artipie.http.hm.SliceHasResponse;
+import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rq.RqMethod;
+import com.artipie.http.rs.RsStatus;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link DownloadArchiveSlice}.
+ * @since 0.4
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+final class DownloadArchiveSliceTest {
+    /**
+     * Test storage.
+     */
+    private Storage storage;
+
+    @BeforeEach
+    void setUp() {
+        this.storage = new InMemoryStorage();
+    }
+
+    @Test
+    void returnsBadRequest() {
+        MatcherAssert.assertThat(
+            new DownloadArchiveSlice(new AstoRepository(this.storage)),
+            new SliceHasResponse(
+                new RsHasStatus(RsStatus.BAD_REQUEST),
+                new RequestLine(RqMethod.GET, "/bad/request")
+            )
+        );
+    }
+
+    @Test
+    void returnsOkStatus() {
+        final String archive = "log-1.1.3.zip";
+        final Key key = new Key.From("artifacts", archive);
+        new TestResource(archive)
+            .saveTo(this.storage, key);
+        MatcherAssert.assertThat(
+            new DownloadArchiveSlice(new AstoRepository(this.storage)),
+            new SliceHasResponse(
+                new RsHasStatus(RsStatus.OK),
+                new RequestLine(RqMethod.GET, key.string()),
+                Headers.EMPTY,
+                new Content.From(new TestResource(archive).asBytes())
+            )
+        );
+    }
+}

--- a/src/test/java/com/artipie/composer/test/ComposerSimple.java
+++ b/src/test/java/com/artipie/composer/test/ComposerSimple.java
@@ -38,11 +38,33 @@ public final class ComposerSimple {
     private final String url;
 
     /**
-     * Ctor.
+     * Package name.
+     */
+    private final String pkg;
+
+    /**
+     * Version of package for uploading.
+     */
+    private final String vers;
+
+    /**
+     * Ctor with default value for package name and version.
      * @param url Repository url
      */
     public ComposerSimple(final String url) {
+        this(url, "vendor/package", "1.1.2");
+    }
+
+    /**
+     * Ctor.
+     * @param url Repository url
+     * @param pkg Package name
+     * @param vers Version of package for uploading
+     */
+    public ComposerSimple(final String url, final String pkg, final String vers) {
         this.url = url;
+        this.pkg = pkg;
+        this.vers = vers;
     }
 
     /**
@@ -67,7 +89,7 @@ public final class ComposerSimple {
             String.format("{\"type\": \"composer\", \"url\": \"%s\"},", this.url),
             "{\"packagist.org\": false} ",
             "],",
-            "\"require\": { \"vendor/package\": \"1.1.2\" }",
+            String.format("\"require\": { \"%s\": \"%s\" }", this.pkg, this.vers),
             "}"
         ).getBytes();
     }


### PR DESCRIPTION
Closes #92
Added IT to verify installation of uploaded archive through `composer` repository. In this case it generates requests to Artipie server, therefore `DownloadArchiveSlice` was added.