### PR TITLE
Made field `version` optional in `Package`

### DIFF
--- a/src/main/java/com/artipie/composer/AstoRepository.java
+++ b/src/main/java/com/artipie/composer/AstoRepository.java
@@ -91,7 +91,7 @@ public final class AstoRepository implements Repository {
     }
 
     @Override
-    public CompletableFuture<Void> addJson(final Content content) {
+    public CompletableFuture<Void> addJson(final Content content, final Optional<String> defvers) {
         final Key key = new Key.From(UUID.randomUUID().toString());
         return this.storage.save(key, content).thenCompose(
             nothing -> this.storage.value(key)
@@ -103,7 +103,7 @@ public final class AstoRepository implements Repository {
                         return CompletableFuture.allOf(
                             this.packages().thenCompose(
                                 packages -> packages.orElse(new JsonPackages())
-                                    .add(pack)
+                                    .add(pack, defvers)
                                     .thenCompose(
                                         pkgs -> pkgs.save(
                                             this.storage, AstoRepository.ALL_PACKAGES
@@ -113,7 +113,7 @@ public final class AstoRepository implements Repository {
                             pack.name().thenCompose(
                                 name -> this.packages(name).thenCompose(
                                     packages -> packages.orElse(new JsonPackages())
-                                        .add(pack)
+                                        .add(pack, defvers)
                                         .thenCompose(
                                             pkgs -> pkgs.save(this.storage, name.key())
                                         )
@@ -154,7 +154,8 @@ public final class AstoRepository implements Repository {
                                         .add(
                                             new JsonPackage(
                                                 new Content.From(this.addDist(compos, key))
-                                            )
+                                            ),
+                                            Optional.empty()
                                         )
                                         .thenCompose(
                                             pkgs -> pkgs.save(

--- a/src/main/java/com/artipie/composer/AstoRepository.java
+++ b/src/main/java/com/artipie/composer/AstoRepository.java
@@ -91,7 +91,7 @@ public final class AstoRepository implements Repository {
     }
 
     @Override
-    public CompletableFuture<Void> addJson(final Content content, final Optional<String> defvers) {
+    public CompletableFuture<Void> addJson(final Content content, final Optional<String> vers) {
         final Key key = new Key.From(UUID.randomUUID().toString());
         return this.storage.save(key, content).thenCompose(
             nothing -> this.storage.value(key)
@@ -103,7 +103,7 @@ public final class AstoRepository implements Repository {
                         return CompletableFuture.allOf(
                             this.packages().thenCompose(
                                 packages -> packages.orElse(new JsonPackages())
-                                    .add(pack, defvers)
+                                    .add(pack, vers)
                                     .thenCompose(
                                         pkgs -> pkgs.save(
                                             this.storage, AstoRepository.ALL_PACKAGES
@@ -113,7 +113,7 @@ public final class AstoRepository implements Repository {
                             pack.name().thenCompose(
                                 name -> this.packages(name).thenCompose(
                                     packages -> packages.orElse(new JsonPackages())
-                                        .add(pack, defvers)
+                                        .add(pack, vers)
                                         .thenCompose(
                                             pkgs -> pkgs.save(this.storage, name.key())
                                         )

--- a/src/main/java/com/artipie/composer/JsonPackage.java
+++ b/src/main/java/com/artipie/composer/JsonPackage.java
@@ -26,6 +26,7 @@ package com.artipie.composer;
 
 import com.artipie.asto.Content;
 import com.artipie.composer.misc.ContentAsJson;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.json.JsonObject;
@@ -58,8 +59,11 @@ public final class JsonPackage implements Package {
     }
 
     @Override
-    public CompletionStage<String> version() {
-        return this.mandatoryString("version");
+    public CompletionStage<Optional<String>> version(final Optional<String> defval) {
+        final String defaultvers = defval.orElse(null);
+        return this.optString("version")
+            .thenApply(opt -> opt.orElse(defaultvers))
+            .thenApply(Optional::ofNullable);
     }
 
     @Override
@@ -94,5 +98,16 @@ public final class JsonPackage implements Package {
                     return res;
                 }
             );
+    }
+
+    /**
+     * Reads string value from package JSON root. Empty in case of absence.
+     * @param name Attribute value
+     * @return String value, otherwise empty.
+     */
+    private CompletionStage<Optional<String>> optString(final String name) {
+        return this.json()
+            .thenApply(json -> json.getString(name, null))
+            .thenApply(Optional::ofNullable);
     }
 }

--- a/src/main/java/com/artipie/composer/JsonPackage.java
+++ b/src/main/java/com/artipie/composer/JsonPackage.java
@@ -59,10 +59,10 @@ public final class JsonPackage implements Package {
     }
 
     @Override
-    public CompletionStage<Optional<String>> version(final Optional<String> defval) {
-        final String defaultvers = defval.orElse(null);
+    public CompletionStage<Optional<String>> version(final Optional<String> value) {
+        final String version = value.orElse(null);
         return this.optString("version")
-            .thenApply(opt -> opt.orElse(defaultvers))
+            .thenApply(opt -> opt.orElse(version))
             .thenApply(Optional::ofNullable);
     }
 

--- a/src/main/java/com/artipie/composer/JsonPackages.java
+++ b/src/main/java/com/artipie/composer/JsonPackages.java
@@ -76,7 +76,7 @@ public final class JsonPackages implements Packages {
     }
 
     @Override
-    public CompletionStage<Packages> add(final Package pack, final Optional<String> defvers) {
+    public CompletionStage<Packages> add(final Package pack, final Optional<String> vers) {
         return new ContentAsJson(this.source)
             .value()
             .thenCompose(
@@ -95,14 +95,14 @@ public final class JsonPackages implements Packages {
                                 } else {
                                     builder = Json.createObjectBuilder(pkgs.getJsonObject(pname));
                                 }
-                                return pack.version(defvers).thenCombine(
+                                return pack.version(vers).thenCombine(
                                     pack.json(),
-                                    (vers, content) -> {
-                                        if (!vers.isPresent()) {
+                                    (vrsn, content) -> {
+                                        if (!vrsn.isPresent()) {
                                             // @checkstyle LineLengthCheck (1 line)
-                                            throw new IllegalStateException(String.format("Failed to add `%s` to packages.json because version is absent", pname));
+                                            throw new IllegalStateException(String.format("Failed to add package `%s` to packages.json because version is absent", pname));
                                         }
-                                        return builder.add(vers.get(), content);
+                                        return builder.add(vrsn.get(), content);
                                     }
                                 ).thenApply(
                                     bldr -> new JsonPackages(

--- a/src/main/java/com/artipie/composer/JsonPackages.java
+++ b/src/main/java/com/artipie/composer/JsonPackages.java
@@ -29,6 +29,7 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.composer.misc.ContentAsJson;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.json.Json;
@@ -75,7 +76,7 @@ public final class JsonPackages implements Packages {
     }
 
     @Override
-    public CompletionStage<Packages> add(final Package pack) {
+    public CompletionStage<Packages> add(final Package pack, final Optional<String> defvers) {
         return new ContentAsJson(this.source)
             .value()
             .thenCompose(
@@ -94,9 +95,15 @@ public final class JsonPackages implements Packages {
                                 } else {
                                     builder = Json.createObjectBuilder(pkgs.getJsonObject(pname));
                                 }
-                                return pack.version().thenCombine(
+                                return pack.version(defvers).thenCombine(
                                     pack.json(),
-                                    builder::add
+                                    (vers, content) -> {
+                                        if (!vers.isPresent()) {
+                                            // @checkstyle LineLengthCheck (1 line)
+                                            throw new IllegalStateException(String.format("Failed to add `%s` to packages.json because version is absent", pname));
+                                        }
+                                        return builder.add(vers.get(), content);
+                                    }
                                 ).thenApply(
                                     bldr -> new JsonPackages(
                                         toContent(

--- a/src/main/java/com/artipie/composer/Package.java
+++ b/src/main/java/com/artipie/composer/Package.java
@@ -42,8 +42,8 @@ public interface Package {
     CompletionStage<Name> name();
 
     /**
-     * Extract version from package. Returns default value if present in case of
-     * absence version.
+     * Extract version from package. Returns passed as a parameter value if present
+     * in case of absence version.
      *
      * @param value Value in case of absence of version. This value can be empty.
      * @return Package version.

--- a/src/main/java/com/artipie/composer/Package.java
+++ b/src/main/java/com/artipie/composer/Package.java
@@ -24,6 +24,7 @@
 
 package com.artipie.composer;
 
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import javax.json.JsonObject;
 
@@ -41,11 +42,13 @@ public interface Package {
     CompletionStage<Name> name();
 
     /**
-     * Extract version from package.
+     * Extract version from package. Returns default value if present in case of
+     * absence version.
      *
+     * @param defaultval Default value in case of absence of version
      * @return Package version.
      */
-    CompletionStage<String> version();
+    CompletionStage<Optional<String>> version(Optional<String> defaultval);
 
     /**
      * Reads package content as JSON object.

--- a/src/main/java/com/artipie/composer/Package.java
+++ b/src/main/java/com/artipie/composer/Package.java
@@ -45,10 +45,10 @@ public interface Package {
      * Extract version from package. Returns default value if present in case of
      * absence version.
      *
-     * @param defaultval Default value in case of absence of version
+     * @param value Value in case of absence of version. This value can be empty.
      * @return Package version.
      */
-    CompletionStage<Optional<String>> version(Optional<String> defaultval);
+    CompletionStage<Optional<String>> version(Optional<String> value);
 
     /**
      * Reads package content as JSON object.

--- a/src/main/java/com/artipie/composer/Packages.java
+++ b/src/main/java/com/artipie/composer/Packages.java
@@ -40,10 +40,11 @@ public interface Packages {
      * Add package.
      *
      * @param pack Package.
-     * @param defversion Default version in case of absence.
+     * @param version Version in case of absence version in package. If package does not
+     *  contain version, this value should be passed as a parameter.
      * @return Updated packages.
      */
-    CompletionStage<Packages> add(Package pack, Optional<String> defversion);
+    CompletionStage<Packages> add(Package pack, Optional<String> version);
 
     /**
      * Saves packages registry binary content to storage.

--- a/src/main/java/com/artipie/composer/Packages.java
+++ b/src/main/java/com/artipie/composer/Packages.java
@@ -27,6 +27,7 @@ package com.artipie.composer;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -39,9 +40,10 @@ public interface Packages {
      * Add package.
      *
      * @param pack Package.
+     * @param defversion Default version in case of absence.
      * @return Updated packages.
      */
-    CompletionStage<Packages> add(Package pack);
+    CompletionStage<Packages> add(Package pack, Optional<String> defversion);
 
     /**
      * Saves packages registry binary content to storage.

--- a/src/main/java/com/artipie/composer/Repository.java
+++ b/src/main/java/com/artipie/composer/Repository.java
@@ -57,10 +57,11 @@ public interface Repository {
      * Adds package described in JSON format from storage.
      *
      * @param content Package content.
-     * @param defversion Default version in case of absence.
+     * @param version Version in case of absence version in content with package. If package
+     *  does not contain version, this value should be passed as a parameter.
      * @return Completion of adding package to repository.
      */
-    CompletableFuture<Void> addJson(Content content, Optional<String> defversion);
+    CompletableFuture<Void> addJson(Content content, Optional<String> version);
 
     /**
      * Adds package described in archive with ZIP or TAR.GZ

--- a/src/main/java/com/artipie/composer/Repository.java
+++ b/src/main/java/com/artipie/composer/Repository.java
@@ -57,9 +57,10 @@ public interface Repository {
      * Adds package described in JSON format from storage.
      *
      * @param content Package content.
+     * @param defversion Default version in case of absence.
      * @return Completion of adding package to repository.
      */
-    CompletableFuture<Void> addJson(Content content);
+    CompletableFuture<Void> addJson(Content content, Optional<String> defversion);
 
     /**
      * Adds package described in archive with ZIP or TAR.GZ

--- a/src/main/java/com/artipie/composer/http/AddSlice.java
+++ b/src/main/java/com/artipie/composer/http/AddSlice.java
@@ -28,10 +28,13 @@ import com.artipie.composer.Repository;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
+import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithStatus;
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.reactivestreams.Publisher;
 
@@ -45,7 +48,7 @@ final class AddSlice implements Slice {
     /**
      * RegEx pattern for matching path.
      */
-    public static final Pattern PATH_PATTERN = Pattern.compile("^/$");
+    public static final Pattern PATH_PATTERN = Pattern.compile("^/(\\?version=(?<version>.*))?$");
 
     /**
      * Repository.
@@ -67,10 +70,18 @@ final class AddSlice implements Slice {
         final Iterable<Map.Entry<String, String>> headers,
         final Publisher<ByteBuffer> body
     ) {
-        return new AsyncResponse(
-            this.repository.addJson(new Content.From(body)).thenApply(
-                nothing -> new RsWithStatus(RsStatus.CREATED)
-            )
-        );
+        final String path = new RequestLineFrom(line).uri().getPath();
+        final Matcher matcher = AddSlice.PATH_PATTERN.matcher(path);
+        final Response resp;
+        if (matcher.matches()) {
+            resp = new AsyncResponse(
+                this.repository.addJson(
+                    new Content.From(body), Optional.ofNullable(matcher.group("version"))
+                ).thenApply(nothing -> new RsWithStatus(RsStatus.CREATED))
+            );
+        } else {
+            resp = new RsWithStatus(RsStatus.BAD_REQUEST);
+        }
+        return resp;
     }
 }

--- a/src/test/java/com/artipie/composer/AstoRepositoryAddJsonTest.java
+++ b/src/test/java/com/artipie/composer/AstoRepositoryAddJsonTest.java
@@ -157,9 +157,9 @@ class AstoRepositoryAddJsonTest {
         return saved.getJsonObject("packages");
     }
 
-    private void addJsonToAsto(final Content json, final Optional<String> defvers) {
+    private void addJsonToAsto(final Content json, final Optional<String> vers) {
         new AstoRepository(this.storage)
-            .addJson(json, defvers)
+            .addJson(json, vers)
             .join();
     }
 

--- a/src/test/java/com/artipie/composer/AstoRepositoryAddJsonTest.java
+++ b/src/test/java/com/artipie/composer/AstoRepositoryAddJsonTest.java
@@ -31,6 +31,7 @@ import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -44,7 +45,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for {@link AstoRepository#addJson(Content)}.
+ * Tests for {@link AstoRepository#addJson(Content, Optional)}.
  *
  * @since 0.4
  * @checkstyle ClassDataAbstractionCouplingCheck (2 lines)
@@ -74,12 +75,14 @@ class AstoRepositoryAddJsonTest {
                 new TestResource("minimal-package.json").asBytes()
             )
         );
-        this.version = this.pack.version().toCompletableFuture().join();
+        this.version = this.pack.version(Optional.empty())
+            .toCompletableFuture().join()
+            .get();
     }
 
     @Test
     void shouldAddPackageToAll() throws Exception {
-        new AstoRepository(this.storage).addJson(this.packageJson()).get();
+        this.addJsonToAsto(this.packageJson(), Optional.empty());
         final Name name = this.pack.name()
             .toCompletableFuture().join();
         MatcherAssert.assertThat(
@@ -94,7 +97,7 @@ class AstoRepositoryAddJsonTest {
             new AllPackages(),
             "{\"packages\":{\"vendor/package\":{\"2.0\":{}}}}".getBytes()
         );
-        new AstoRepository(this.storage).addJson(this.packageJson()).get();
+        this.addJsonToAsto(this.packageJson(), Optional.empty());
         MatcherAssert.assertThat(
             this.packages().getJsonObject("vendor/package").keySet(),
             new IsEqual<>(new SetOf<>("2.0", this.version))
@@ -103,12 +106,12 @@ class AstoRepositoryAddJsonTest {
 
     @Test
     void shouldAddPackage() throws Exception {
-        new AstoRepository(this.storage).addJson(this.packageJson()).get();
+        this.addJsonToAsto(this.packageJson(), Optional.empty());
         final Name name = this.pack.name()
             .toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Package with correct version should present in packages after being added",
-            this.packages(name).getJsonObject(name.string()).keySet(),
+            this.packages(name.key()).getJsonObject(name.string()).keySet(),
             new IsEqual<>(new SetOf<>(this.version))
         );
     }
@@ -121,18 +124,18 @@ class AstoRepositoryAddJsonTest {
             name.key(),
             "{\"packages\":{\"vendor/package\":{\"1.1.0\":{}}}}".getBytes()
         );
-        new AstoRepository(this.storage).addJson(this.packageJson()).get();
+        this.addJsonToAsto(this.packageJson(), Optional.empty());
         MatcherAssert.assertThat(
             // @checkstyle LineLengthCheck (1 line)
             "Package with both new and old versions should present in packages after adding new version",
-            this.packages(name).getJsonObject(name.string()).keySet(),
+            this.packages(name.key()).getJsonObject(name.string()).keySet(),
             new IsEqual<>(new SetOf<>("1.1.0", this.version))
         );
     }
 
     @Test
     void shouldDeleteSourceAfterAdding() throws Exception {
-        new AstoRepository(this.storage).addJson(this.packageJson()).get();
+        this.addJsonToAsto(this.packageJson(), Optional.empty());
         MatcherAssert.assertThat(
             this.storage.list(Key.ROOT).join().stream()
                 .map(Key::string)
@@ -145,10 +148,6 @@ class AstoRepositoryAddJsonTest {
         return this.packages(new AllPackages());
     }
 
-    private JsonObject packages(final Name name) {
-        return this.packages(name.key());
-    }
-
     private JsonObject packages(final Key key) {
         final JsonObject saved;
         final byte[] bytes = new BlockingStorage(this.storage).value(key);
@@ -158,14 +157,20 @@ class AstoRepositoryAddJsonTest {
         return saved.getJsonObject("packages");
     }
 
+    private void addJsonToAsto(final Content json, final Optional<String> defvers) {
+        new AstoRepository(this.storage)
+            .addJson(json, defvers)
+            .join();
+    }
+
     private Content packageJson() throws Exception {
         final byte[] bytes;
-        try (ByteArrayOutputStream out = new ByteArrayOutputStream();
-            JsonWriter writer = Json.createWriter(out)) {
-            writer.writeObject(this.pack.json().toCompletableFuture().join());
-            out.flush();
-            bytes = out.toByteArray();
-        }
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final JsonWriter writer = Json.createWriter(out);
+        writer.writeObject(this.pack.json().toCompletableFuture().join());
+        out.flush();
+        bytes = out.toByteArray();
+        writer.close();
         return new Content.From(bytes);
     }
 }

--- a/src/test/java/com/artipie/composer/JsonPackageTest.java
+++ b/src/test/java/com/artipie/composer/JsonPackageTest.java
@@ -26,6 +26,7 @@ package com.artipie.composer;
 
 import com.artipie.asto.Content;
 import com.artipie.asto.test.TestResource;
+import java.util.Optional;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,7 +66,9 @@ class JsonPackageTest {
     @Test
     void shouldExtractVersion() {
         MatcherAssert.assertThat(
-            this.pack.version().toCompletableFuture().join(),
+            this.pack.version(Optional.empty())
+                .toCompletableFuture().join()
+                .get(),
             new IsEqual<>("1.2.0")
         );
     }

--- a/src/test/java/com/artipie/composer/JsonPackagesTest.java
+++ b/src/test/java/com/artipie/composer/JsonPackagesTest.java
@@ -31,6 +31,7 @@ import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
 import com.artipie.composer.misc.ContentAsJson;
+import java.util.Optional;
 import javax.json.JsonObject;
 import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
@@ -102,8 +103,9 @@ class JsonPackagesTest {
         final JsonObject json = this.addPackageTo("{\"packages\":{}}");
         MatcherAssert.assertThat(
             this.versions(json).getJsonObject(
-                this.pack.version()
+                this.pack.version(Optional.empty())
                     .toCompletableFuture().join()
+                    .get()
             ),
             new IsNot<>(new IsNull<>())
         );
@@ -118,7 +120,10 @@ class JsonPackagesTest {
         MatcherAssert.assertThat(
             versions.keySet(),
             new IsEqual<>(
-                new SetOf<>("1.1.0", this.pack.version().toCompletableFuture().join())
+                new SetOf<>(
+                    "1.1.0",
+                    this.pack.version(Optional.empty()).toCompletableFuture().join().get()
+                )
             )
         );
     }
@@ -126,7 +131,7 @@ class JsonPackagesTest {
     private JsonObject addPackageTo(final String original) {
         final Key key = this.name.key();
         new JsonPackages(new Content.From(original.getBytes()))
-            .add(this.pack)
+            .add(this.pack, Optional.empty())
             .toCompletableFuture().join()
             .save(this.storage, key)
             .toCompletableFuture().join();


### PR DESCRIPTION
Part of #83 
Made field `version` optional in `Package`. Also, in other places it required to refactor. 
Now it is possible to pass through parameter default value for version in case of absence of version.